### PR TITLE
set default value for helmrelease chart directory

### DIFF
--- a/pkg/controller/helmrelease/helmrelease_controller.go
+++ b/pkg/controller/helmrelease/helmrelease_controller.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -71,12 +70,9 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	chartsDir := os.Getenv(appv1.ChartsDir)
 	if chartsDir == "" {
-		chartsDir, err := ioutil.TempDir("/tmp", "charts")
-		if err != nil {
-			return err
-		}
+		chartsDir = "/tmp/hr-charts"
 
-		err = os.Setenv(appv1.ChartsDir, chartsDir)
+		err := os.Setenv(appv1.ChartsDir, chartsDir)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/helmrelease/helmreleasemgr.go
+++ b/pkg/controller/helmrelease/helmreleasemgr.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/ghodss/yaml"
@@ -104,11 +103,7 @@ func downloadChart(client client.Client, s *appv1.HelmRelease) (string, error) {
 
 	chartsDir := os.Getenv(appv1.ChartsDir)
 	if chartsDir == "" {
-		chartsDir, err = ioutil.TempDir("/tmp", "charts")
-		if err != nil {
-			klog.Error(err, " - Can not create tempdir")
-			return "", err
-		}
+		chartsDir = "/tmp/hr-charts"
 	}
 
 	chartDir, err := utils.DownloadChart(configMap, secret, chartsDir, s)


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

Back porting changes from https://github.com/stolostron/multicloud-operators-subscription/pull/655 to release-2.4 branch

After this is merged, we still need to update the subscription side to use the new HR version and `metaupdate.go`

For https://github.com/stolostron/backlog/issues/19823